### PR TITLE
Version 0.3.0 release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   # == CHECK == #
   check:
-    name: "Check beta stable and MSRV=1.45.0"
+    name: "Check beta stable and MSRV=1.65.0"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust-toolchains:
-          - 1.45.0
+          - 1.65.0
           - stable
           - beta
         cargo-locked: ["--locked", ""]
@@ -28,14 +28,6 @@ jobs:
 
       - name: Clone repo
         uses: actions/checkout@v2
-
-      # See https://github.com/rust-lang/cargo/issues/10303
-      - name: cargo fetch (≤1.45.0 compatible)
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
-        with:
-          command: fetch
 
       - name: Update `Cargo.lock`
         if: matrix.cargo-locked != '--locked'
@@ -60,7 +52,7 @@ jobs:
           - macos-latest
           - windows-latest
         rust-toolchains:
-          - 1.45.0
+          - 1.65.0
           - stable
     steps:
       - name: Install Rust toolchain
@@ -72,14 +64,6 @@ jobs:
 
       - name: Clone repo
         uses: actions/checkout@v2
-
-      # See https://github.com/rust-lang/cargo/issues/10303
-      - name: cargo fetch (≤1.45.0 compatible)
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
-        with:
-          command: fetch
 
       - name: Cargo test
         uses: actions-rs/cargo@v1
@@ -108,14 +92,6 @@ jobs:
 
       - name: Clone repo
         uses: actions/checkout@v2
-
-      # See https://github.com/rust-lang/cargo/issues/10303
-      - name: cargo fetch (≤1.45.0 compatible)
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
-        with:
-          command: fetch
 
       - name: Cargo UI test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -21,7 +21,7 @@ jobs:
           - macos-latest
           - windows-latest
         rust-toolchains:
-          - 1.45.0
+          - 1.65.0
           - stable
           - beta
           - nightly
@@ -37,14 +37,6 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      # See https://github.com/rust-lang/cargo/issues/10303
-      - name: cargo fetch (≤1.45.0 compatible)
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
-        with:
-          command: fetch
-
       - name: Update `Cargo.lock`
         if: matrix.cargo-locked != '--locked'
         run: cargo update -v
@@ -56,7 +48,7 @@ jobs:
           args: ${{ matrix.cargo-locked }}
 
       - name: Cargo test (embed `README.md` + UI)
-        if: matrix.rust-toolchains != '1.45.0'
+        if: matrix.rust-toolchains != '1.65.0'
         uses: actions-rs/cargo@v1
         with:
           command: test-ui

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "byte-strings"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "byte-strings-proc_macros",
 ]
 
 [[package]]
 name = "byte-strings-proc_macros"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -20,35 +20,35 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.0"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f287c234c9b2d0308d692dee5c449c1a171167a6f8150f7cf2a49d8fd96967"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.0"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.7"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "unicode-ident"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ name = "byte-strings"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.2"  # Keep in sync
+version = "0.3.0"  # Keep in sync
 edition = "2018"
+rust-version = "1.65.0"
 
 license = "Zlib OR MIT OR Apache-2.0"
 repository = "https://github.com/danielhenrymantilla/byte-strings-rs"
@@ -19,14 +20,14 @@ categories = ["api-bindings", "rust-patterns"]
 
 [features]
 better-docs = []  # allowed to break MSRV
-ui-tests = ["better-docs", "const-friendly"]
-const-friendly = []  # allowed to break MSRV
+ui-tests = ["better-docs"]
+const-friendly = []  # Deprecated: now enabled by default.
 
 [dependencies]
 
 [dependencies.byte-strings-proc_macros]
 path = "src/proc_macros"
-version = "0.2.2"  # Keep in sync
+version = "=0.3.0"  # Keep in sync
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/danielhenrymantilla/byte-strings-rs)
 https://crates.io/crates/byte-strings)
 [![Documentation](https://docs.rs/byte-strings/badge.svg)](
 https://docs.rs/byte-strings)
-[![MSRV](https://img.shields.io/badge/MSRV-1.45.0-white)](
+[![MSRV](https://img.shields.io/badge/MSRV-1.65.0-white)](
 https://gist.github.com/danielhenrymantilla/8e5b721b3929084562f8f65668920c33)
 [![License](https://img.shields.io/crates/l/byte-strings.svg)](
 https://github.com/danielhenrymantilla/byte-strings-rs/blob/master/LICENSE-ZLIB)

--- a/change_version.sh
+++ b/change_version.sh
@@ -8,7 +8,7 @@ find . \
     -print \
     -a \
     -exec \
-        sed -i -E "s/\".*?\"(  # Keep in sync)/\"$1\"\\1/g" '{}' \
+        sed -i -E "s/\"(=)?.*\"(  # Keep in sync)/\"\\1$1\"\\2/g" '{}' \
     \;
 
 cargo +stable update -v -w

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = '1.45.0'
+channel = '1.65.0'
 # Templated by `cargo-generate` using https://github.com/danielhenrymantilla/proc-macro-template

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-#![cfg_attr(feature = "better-docs",
-    cfg_attr(all(), doc = include_str!("../README.md")),
-)]
+#![doc = include_str!("../README.md")]
+#![no_std]
+
 // Fix rendering of `<details><summary>` within bulleted lists:
 // Credit for this marvelous hack go to: https://github.com/rust-lang/cargo/issues/331#issuecomment-479847157
 #![doc(html_favicon_url = "\">
@@ -55,7 +55,7 @@ macro_rules! concat_bytes {(
 /// made of all the bytes of the given literals concatenated left-to-right,
 /// **with an appended null byte terminator**.
 ///
-/// Hence the macro evaluates to the type `&'static ::std::ffi::CStr`.
+/// Hence the macro evaluates to the type `&'static ::core::ffi::CStr`.
 ///
 /// # Example
 ///
@@ -117,11 +117,9 @@ mod __ {
     pub use {
         ::byte_strings_proc_macros::*,
         ::core,
-        ::std,
     };
 }
 
-#[cfg(feature = "const-friendly")]
 #[path = "const.rs"]
 pub mod const_;
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "byte-strings-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.2"  # Keep in sync
+version = "0.3.0"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ description = "Internal: proc-macro backend of ::byte_strings."
 [dependencies]
 proc-macro2.version = "1.0.0"
 quote.version = "1.0.0"
-syn.version = "1.0.7"  # Access to `receiver()`.
+syn.version = "2.0.0"
 syn.features = [
     "full",
 ]

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -109,15 +109,13 @@ fn c_str_impl (
     let byte_string_literal = LitByteStr::new(bytes, Span::call_site());
     Ok(quote!(
         {
-            let stmt_expr_attr_workaround;
             #[allow(unused_unsafe)] {
-                stmt_expr_attr_workaround = unsafe {
-                    #crate_::__::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                unsafe {
+                    #crate_::__::core::ffi::CStr::from_bytes_with_nul_unchecked(
                         #byte_string_literal
                     )
-                };
+                }
             }
-            stmt_expr_attr_workaround
         }
     ))
 }


### PR DESCRIPTION
  - Bumped MSRV to 1.65.0 so as to:
      - be `#![no_std]` (fixes #6)
      - depend on syn 2.0 (fixes #7)
      - not require the `const_friendly` opt-in Cargo feature (removed!)
  - Removed the `const_friendly` feature, and the `CStr` item
  - Pin the proc-macro version w.r.t. the frontend crate.

TODO: Remove the proc-macros altogether?