### PR TITLE
Avoid having the `$right` expression of `concat_bytes!` in a submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "byte-strings"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byte-strings-proc_macros",
 ]
 
 [[package]]
 name = "byte-strings-proc_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "byte-strings"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.3.0"  # Keep in sync
+version = "0.3.1"  # Keep in sync
 edition = "2018"
 rust-version = "1.65.0"
 
@@ -27,7 +27,7 @@ const-friendly = []  # Deprecated: now enabled by default.
 
 [dependencies.byte-strings-proc_macros]
 path = "src/proc_macros"
-version = "=0.3.0"  # Keep in sync
+version = "=0.3.1"  # Keep in sync
 
 [dev-dependencies]
 

--- a/src/const.rs
+++ b/src/const.rs
@@ -259,21 +259,16 @@ macro_rules! __concat_bytes_two {(
     $right:expr $(,)?
 ) => ({
     const LEFT: &'static [$crate::__::core::primitive::u8] = $left;
-    const __RIGHT: &'static [$crate::__::core::primitive::u8] = {
-        mod __ {
-            pub const RIGHT: &[$crate::__::core::primitive::u8] = $right;
-        }
-        __::RIGHT
-    };
+    const RIGHT: &'static [$crate::__::core::primitive::u8] = $right;
     unsafe {
         use $crate::const_::__::{Contiguous, core::{self, primitive::*, mem}};
         const LEFT_LEN: usize = LEFT.len();
         const LEFT_BYTES: &'static [u8; LEFT_LEN] = unsafe {
             mem::transmute(LEFT.as_ptr())
         };
-        const RIGHT_LEN: usize = __RIGHT.len();
+        const RIGHT_LEN: usize = RIGHT.len();
         const RIGHT_BYTES: &'static [u8; RIGHT_LEN] = unsafe {
-            mem::transmute(__RIGHT.as_ptr())
+            mem::transmute(RIGHT.as_ptr())
         };
         const CONCAT_CONTIGUOUS: (
             &'static Contiguous<

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "byte-strings-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.3.0"  # Keep in sync
+version = "0.3.1"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"


### PR DESCRIPTION
Indeed, I was somehow convinced that:

```rs
const RIGHT: u8 = {
    const LEFT: u8 = 42;
    const RIGHT: u8 = {
        const LEFT: u8 = 42;
        const RIGHT: u8 = 27;
        LEFT + RIGHT
    };
    LEFT + RIGHT
};
```

was gonna give problems but it does not 🤷 